### PR TITLE
kNN, replacement-length param to be calibrated

### DIFF
--- a/cz1_clean_FMLA.py
+++ b/cz1_clean_FMLA.py
@@ -1,0 +1,313 @@
+"""
+This program takes the FMLA data and cleans it into a format to be used
+for behavioral estimation
+"""
+
+# Housekeeping
+import pandas as pd
+pd.set_option('display.max_columns', 999)
+pd.set_option('display.width', 200)
+import numpy as np
+
+# Read in FMLA data
+d = pd.read_csv("data/fmla_2012/fmla_2012_employee_restrict_puf.csv")
+
+# FMLA eligible worker
+d['eligworker'] = np.where((d['E13']==1) & ((d['E14'] == 1) | ((d['E15_CAT'] >= 5) & (d['E15_CAT'] <= 8))), 1, 0)
+d['eligworker'] = np.where((np.isnan(d['E13'])) & (np.isnan(d['E14'])) & (np.isnan(d['E15_CAT'])), np.nan,d['eligworker'])
+
+# Covered workplace
+d['covwrkplace'] = np.where((d['E11']==1) | ((d['E12'] >= 6) & (d['E12'] <= 9)), 1, 0)
+d['covwrkplace'] = np.where(np.isnan(d['covwrkplace']) , 0, d['covwrkplace'])
+d['cond1']       = np.where(np.isnan(d['E11']) & np.isnan(d['E12']) , 1,0)
+d['cond2']       = np.where((d['E11']==2) & (np.isnan(d['E11'])==False) & np.isnan(d['E12']),1,0)
+d['miscond']     = np.where((d['cond1']==1) | (d['cond2']==1),1,0)
+d['covwrkplace'] = np.where(d['miscond']==1,np.nan,d['covwrkplace'])
+
+# Covered and eligible
+d['coveligd'] = np.where((d['covwrkplace']==1) & (d['eligworker']==1) ,1,0)
+d['coveligd'] = np.where(np.isnan(d['covwrkplace']) & np.isnan(d['eligworker']),np.nan,d['coveligd'])
+d['coveligd'] = np.where(np.isnan(d['covwrkplace']) & (d['eligworker']==1),np.nan,d['coveligd'])
+d['coveligd'] = np.where((d['covwrkplace']==1) & np.isnan(d['eligworker']),np.nan,d['coveligd'])
+
+# Hourly worker
+d['hourly'] = np.where(d['E9_1']==2,1,0)
+d['hourly'] = np.where(np.isnan(d['E9_1']),np.nan,d['hourly'])
+
+# Union member
+d['union'] = np.where(d['D3']==1,1,0)
+d['union'] = np.where(np.isnan(d['D3']),np.nan,d['union'])
+
+# Employment Status
+d['employed'] = np.where(d['E1']==1, 1, 0)
+d['employed'] = np.where(np.isnan(d['E1']),np.nan,d['employed'])
+
+# Hours per week
+    # a dict to map code into average numeric hours per week
+dict_wkhours = {
+    1: 4,
+    2: 11.5,
+    3: 17,
+    4: 21.5,
+    5: 26.5,
+    6: 32,
+    7: 37.5,
+    8: 45,
+    'nan': np.nan
+}
+d['wkhours'] = d['E15_CAT_REV'].map(dict_wkhours)
+
+
+# Employment at government
+    # all rows should be valid for empgov_[] indicators, given FMLA sample
+d['empgov_fed'] = np.where(d['D2']==1, 1, 0)
+d['empgov_st'] = np.where(d['D2']==2, 1, 0)
+d['empgov_loc'] = np.where(d['D2']==3, 1, 0)
+
+# Age at midpoint of category
+conditions = [(d['AGE_CAT'] == 1),(d['AGE_CAT'] == 2),
+              (d['AGE_CAT'] == 3),(d['AGE_CAT'] == 4),
+              (d['AGE_CAT'] == 5),(d['AGE_CAT'] == 6),
+              (d['AGE_CAT'] == 7),(d['AGE_CAT'] == 8),
+              (d['AGE_CAT'] == 9),(d['AGE_CAT'] == 10)]
+choices = [21,27,32,37,42,47,52,57,63.5,70]
+d['age']   = np.select(conditions, choices, default=np.nan)
+d['agesq'] = np.array(d['age'])**2
+
+# Sex
+d['male']   = np.where(d['GENDER_CAT']==1,1,0)
+d['female'] = np.where(d['GENDER_CAT']==2,1,0)
+
+# No children
+d['nochildren'] = np.where(d['D7_CAT']==0,1,0)
+d['nochildren'] = np.where(np.isnan(d['D7_CAT']),np.nan,d['nochildren'])
+
+# Number of dependents
+d['ndep_kid'] = d.D7_CAT
+d['ndep_old'] = d.D8_CAT
+
+# Educational level
+d['ltHS'] = np.where(d['D1_CAT']==1,1,0)
+d['ltHS'] = np.where(np.isnan(d['D1_CAT']),np.nan,d['ltHS'])
+
+d['someHS'] = np.where(d['D1_CAT']==2,1,0)
+d['someHS'] = np.where(np.isnan(d['D1_CAT']),np.nan,d['someHS'])
+
+d['HSgrad'] = np.where(d['D1_CAT']==3,1,0)
+d['HSgrad'] = np.where(np.isnan(d['D1_CAT']),np.nan,d['HSgrad'])
+
+d['someCol'] = np.where(d['D1_CAT']==5,1,0)
+d['someCol'] = np.where(np.isnan(d['D1_CAT']),np.nan,d['someCol'])
+
+d['BA'] = np.where(d['D1_CAT']==6,1,0)
+d['BA'] = np.where(np.isnan(d['D1_CAT']),np.nan,d['BA'])
+
+d['GradSch'] = np.where(d['D1_CAT']==7,1,0)
+d['GradSch'] = np.where(np.isnan(d['D1_CAT']),np.nan,d['GradSch'])
+
+d['noHSdegree'] = np.where((d['ltHS']==1) | (d['someHS']==1),1,0)
+d['noHSdegree'] = np.where(np.isnan(d['ltHS']) & np.isnan(d['someHS']),np.nan,d['noHSdegree'])
+
+d['BAplus'] = np.where((d['BA']==1) | (d['GradSch']==1),1,0)
+d['BAplus'] = np.where(np.isnan(d['BA']) & np.isnan(d['GradSch']),np.nan,d['BAplus'])
+
+# Family income using midpoint of category
+conditions = [(d['D4_CAT'] == 3),(d['D4_CAT'] == 4),
+              (d['D4_CAT'] == 5),(d['D4_CAT'] == 6),
+              (d['D4_CAT'] == 7),(d['D4_CAT'] == 8),
+              (d['D4_CAT'] == 9),(d['D4_CAT'] == 10)]
+choices = [15,25,32.5,37.5,45,62.5,87.5,130]
+d['faminc'] = np.select(conditions, choices, default=np.nan)
+d['lnfaminc'] = np.log(d['faminc'])
+
+# Marital status
+d['married'] = np.where(d['D10']==1,1,0)
+d['married'] = np.where(np.isnan(d['D10']),np.nan,d['married'])
+
+d['partner'] = np.where(d['D10']==2,1,0)
+d['partner'] = np.where(np.isnan(d['D10']),np.nan,d['partner'])
+
+d['separated'] = np.where(d['D10']==3,1,0)
+d['separated'] = np.where(np.isnan(d['D10']),np.nan,d['separated'])
+
+d['divorced'] = np.where(d['D10']==4,1,0)
+d['divorced'] = np.where(np.isnan(d['D10']),np.nan,d['divorced'])
+
+d['widowed'] = np.where(d['D10']==5,1,0)
+d['widowed'] = np.where(np.isnan(d['D10']),np.nan,d['widowed'])
+
+d['nevermarried'] = np.where(d['D10']==6,1,0)
+d['nevermarried'] = np.where(np.isnan(d['D10']),np.nan,d['nevermarried'])
+
+# Race/ethnicity
+d['raceth'] = np.where((np.isnan(d['D5'])==False) & (d['D5']==1),7,d['D6_1_CAT'])
+
+d['native'] = np.where(d['raceth']==1,1,0)
+d['native'] = np.where(np.isnan(d['raceth']),np.nan,d['native'])
+
+d['asian'] = np.where(d['raceth']==2,1,0)
+d['asian'] = np.where(np.isnan(d['raceth']),np.nan,d['asian'])
+
+d['black'] = np.where(d['raceth']==4,1,0)
+d['black'] = np.where(np.isnan(d['raceth']),np.nan,d['black'])
+
+d['white'] = np.where(d['raceth']==5,1,0)
+d['white'] = np.where(np.isnan(d['raceth']),np.nan,d['white'])
+
+d['other'] = np.where(d['raceth']==6,1,0)
+d['other'] = np.where(np.isnan(d['raceth']),np.nan,d['other'])
+
+d['hisp'] = np.where(d['raceth']==7,1,0)
+d['hisp'] = np.where(np.isnan(d['raceth']),np.nan,d['hisp'])
+
+# leave reason for most recent leave
+d['reason_take'] = np.where((np.isnan(d['A20'])==False) & (d['A20']==2),d['A5_2_CAT'],d['A5_1_CAT'])
+
+# leave reason for most recent leave (revised)
+d['reason_take_rev'] = np.where((np.isnan(d['A20'])==False) & (d['A20']==2),d['A5_2_CAT_REV'],d['A5_1_CAT_rev'])
+
+# taken doctor
+d['YNdoctor_take'] = np.where((np.isnan(d['A20'])==False) & (d['A20']==2),d['A11_2'],d['A11_1'])
+d['doctor_take']   = np.where(d['YNdoctor_take']==1,1,0)
+d['doctor_take']   = np.where(np.isnan(d['YNdoctor_take']),np.nan,d['doctor_take'])
+
+# taken hospital
+d['YNhospital_take'] = np.where((np.isnan(d['A20'])==False) & (d['A20']==2),d['A12_2'],d['A12_1'])
+d['hospital_take']   = np.where(d['YNhospital_take']==1,1,0)
+d['hospital_take']   = np.where(np.isnan(d['YNhospital_take']),np.nan,d['hospital_take'])
+d['hospital_take']   = np.where(np.isnan(d['hospital_take']) & (d['doctor_take']==0),0,d['hospital_take'])
+
+# need doctor
+d['doctor_need'] = np.where(d['B12_1']==1,1,0)
+d['doctor_need'] = np.where(np.isnan(d['B12_1']),np.nan,d['doctor_need'])
+
+# need hospital
+d['hospital_need'] = np.where(d['B13_1']==1,1,0)
+d['hospital_need'] = np.where(np.isnan(d['B13_1']),np.nan,d['hospital_need'])
+d['hospital_need'] = np.where(np.isnan(d['hospital_need']) & (d['doctor_need']==0),0,d['hospital_need'])
+
+# taken or needed doctor or hospital for leave category
+d['doctor1'] = np.where((np.isnan(d['B13_1'])==False) & (d['LEAVE_CAT']==2),d['doctor_need'],d['doctor_take'])
+d['doctor2'] = np.where((np.isnan(d['LEAVE_CAT'])==False) & ((d['LEAVE_CAT']==2) | (d['LEAVE_CAT']==4)),d['doctor_need'],d['doctor_take'])
+
+d['hospital1'] = np.where((np.isnan(d['LEAVE_CAT'])==False) & (d['LEAVE_CAT']==2),d['hospital_need'],d['hospital_take'])
+d['hospital2'] = np.where((np.isnan(d['LEAVE_CAT'])==False) & ((d['LEAVE_CAT']==2) | (d['LEAVE_CAT']==4)),d['hospital_need'],d['hospital_take'])
+
+# length of leave for most recent leave
+d['length']     = np.where((np.isnan(d['A20'])==False) & (d['A20']==2),d['A19_2_CAT_rev'],d['A19_1_CAT_rev'])
+d['lengthsq']   = np.array(d['length'])**2
+d['lnlength']   = np.log(d['length'])
+d['lnlengthsq'] = np.log(d['length'])**2
+
+# any pay received
+d['anypay'] = np.where(d['A45']==1,1,0)
+d['anypay'] = np.where(np.isnan(d['A45']),np.nan,d['anypay'])
+
+# state program
+d['recStateFL'] = np.where(d['A48b']==1,1,0)
+d['recStateFL'] = np.where(np.isnan(d['A48b']),np.nan,d['recStateFL'])
+d['recStateFL'] = np.where(np.isnan(d['recStateFL']) & (d['anypay']==0),0,d['recStateFL'])
+
+d['recStateDL'] = np.where(d['A48c']==1,1,0)
+d['recStateDL'] = np.where(np.isnan(d['A48c']),np.nan,d['recStateDL'])
+d['recStateDL'] = np.where(np.isnan(d['recStateDL']) & (d['anypay']==0),0,d['recStateDL'])
+
+d['recStatePay'] = np.where((d['recStateFL']==1) | (d['recStateDL']==1),1,0)
+d['recStatePay'] = np.where(np.isnan(d['recStateFL']) | np.isnan(d['recStateDL']),np.nan,d['recStatePay'])
+
+# fully paid
+d['fullyPaid'] = np.where(d['A49']==1,1,0)
+d['fullyPaid'] = np.where(np.isnan(d['A49']),np.nan,d['fullyPaid'])
+
+# longer leave if more pay
+d['longerLeave'] = np.where(d['A55']==1,1,0)
+d['longerLeave'] = np.where(np.isnan(d['A55']),np.nan,d['longerLeave'])
+
+# could not afford to take leave
+d['unaffordable'] = np.where(d['B15_1_CAT']==5,1,0)
+d['unaffordable'] = np.where(np.isnan(d['B15_1_CAT']),np.nan,d['unaffordable'])
+
+# weights
+w_emp             = np.mean(d[d['LEAVE_CAT'] == 3]['weight'])
+w_leave           = np.mean(d[d['LEAVE_CAT'] != 3]['weight'])
+d['fixed_weight'] = np.where(d['LEAVE_CAT']==3,w_emp,w_leave)
+d['freq_weight']  = np.round(d['weight'])
+
+
+# --------------------------
+# dummies for leave type 
+# --------------------------
+
+# there are three variables for each leave type:
+# (1) taking a leave
+# (2) needing a leave
+# (3) taking or needing a leave
+
+# maternity disability
+d['take_matdis'] = np.where(((d['A5_1_CAT']==21)&(d['A11_1']==1)&(d['GENDER_CAT']==2)) | (d['A5_1_CAT_rev']==32),1,0)
+d['take_matdis'] = np.where(np.isnan(d['take_matdis']),0,d['take_matdis'])
+d['take_matdis'] = np.where(np.isnan(d['A5_1_CAT']),np.nan,d['take_matdis'])
+d['take_matdis'] = np.where(np.isnan(d['take_matdis']) & ((d['LEAVE_CAT']==2) | (d['LEAVE_CAT']==3)),0,d['take_matdis'])
+
+d['need_matdis'] = np.where(((d['B6_1_CAT']==21)&(d['B12_1']==1)&(d['GENDER_CAT']==2)) | (d['B6_1_CAT_rev']==32),1,0)
+d['need_matdis'] = np.where(np.isnan(d['need_matdis']),0,d['need_matdis'])
+d['need_matdis'] = np.where(np.isnan(d['B6_1_CAT']),np.nan,d['need_matdis'])
+d['need_matdis'] = np.where(np.isnan(d['need_matdis']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['need_matdis'])
+
+d['type_matdis'] = np.where((d['take_matdis']==1) | (d['need_matdis']==1),1,0)
+d['type_matdis'] = np.where(np.isnan(d['take_matdis']) | np.isnan(d['need_matdis']),np.nan,d['type_matdis'])
+
+# new child/bond
+d['take_bond'] = np.where((d['A5_1_CAT']==21) & (np.isnan(d['A11_1']) | (d['GENDER_CAT']==1) | ((d['GENDER_CAT']==2) & (d['A11_1']==2) & (d['A5_1_CAT_rev']!=32))),1,0)
+d['take_bond'] = np.where(np.isnan(d['A5_1_CAT']),np.nan,d['take_bond'])
+d['take_bond'] = np.where(np.isnan(d['take_bond']) & ((d['LEAVE_CAT']==2) | (d['LEAVE_CAT']==3)),0,d['take_bond'])
+
+d['need_bond'] = np.where((d['B6_1_CAT']==21) & (np.isnan(d['B12_1']) | (d['GENDER_CAT']==1) | ((d['GENDER_CAT']==2) & (d['B12_1']==2) & (d['B6_1_CAT_rev']!=32))),1,0)
+d['need_bond'] = np.where(np.isnan(d['B6_1_CAT']),np.nan,d['need_bond'])
+d['need_bond'] = np.where(np.isnan(d['need_bond']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['need_bond'])
+
+d['type_bond'] = np.where((d['take_bond']==1) | (d['need_bond']==1),1,0)
+d['type_bond'] = np.where(np.isnan(d['take_bond']) | np.isnan(d['need_bond']),np.nan,d['type_bond'])
+
+# own health
+d['take_own'] = np.where(d['reason_take']==1,1,0)
+d['take_own'] = np.where(np.isnan(d['take_own']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['take_own'])
+
+d['need_own'] = np.where(d['B6_1_CAT']==1,1,0)
+d['need_own'] = np.where(np.isnan(d['need_own']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['need_own'])
+
+d['type_own'] = np.where((d['take_own']==1) | (d['need_own']==1),1,0)
+d['type_own'] = np.where(np.isnan(d['take_own']) | np.isnan(d['need_own']),np.nan,d['type_own'])
+
+#ill child
+d['take_illchild'] = np.where(d['reason_take']==11,1,0)
+d['take_illchild'] = np.where(np.isnan(d['take_illchild']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['take_illchild'])
+
+d['need_illchild'] = np.where(d['B6_1_CAT']==11,1,0)
+d['need_illchild'] = np.where(np.isnan(d['need_illchild']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['need_illchild'])
+
+d['type_illchild'] = np.where((d['take_illchild']==1) | (d['need_illchild']==1),1,0)
+d['type_illchild'] = np.where(np.isnan(d['take_illchild']) | np.isnan(d['need_illchild']),np.nan,d['type_illchild'])
+
+#ill spouse
+d['take_illspouse'] = np.where(d['reason_take']==12,1,0)
+d['take_illspouse'] = np.where(np.isnan(d['take_illspouse']) & ((d['LEAVE_CAT']==2) | (d['LEAVE_CAT']==3)),0,d['take_illspouse'])
+
+d['need_illspouse'] = np.where(d['B6_1_CAT']==12,1,0)
+d['need_illspouse'] = np.where(np.isnan(d['need_illspouse']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['need_illspouse'])
+
+d['type_illspouse'] = np.where((d['take_illspouse']==1) | (d['need_illspouse']==1),1,0)
+d['type_illspouse'] = np.where(np.isnan(d['take_illspouse']) | np.isnan(d['need_illspouse']),np.nan,d['type_illspouse'])
+
+#ill parent
+d['take_illparent'] = np.where(d['reason_take']==13,1,0)
+d['take_illparent'] = np.where(np.isnan(d['take_illparent']) & ((d['LEAVE_CAT']==2) | (d['LEAVE_CAT']==3)),0,d['take_illparent'])
+
+d['need_illparent'] = np.where(d['B6_1_CAT']==13,1,0)
+d['need_illparent'] = np.where(np.isnan(d['need_illparent']) & ((d['LEAVE_CAT']==1) | (d['LEAVE_CAT']==3)),0,d['need_illparent'])
+
+d['type_illparent'] = np.where((d['take_illparent']==1) | (d['need_illparent']==1),1,0)
+d['type_illparent'] = np.where(np.isnan(d['take_illparent']) | np.isnan(d['need_illparent']),np.nan,d['type_illparent'])
+
+# Save data
+d.to_csv("data/fmla_clean_2012.csv", index=False, header=True)

--- a/cz1a_get_response.py
+++ b/cz1a_get_response.py
@@ -1,0 +1,228 @@
+'''
+get response of leave taking in presence of new program
+
+To do: need a hyperparameter alpha to capture effect of program generosity (replacement rate) on response length
+
+can use California data (with current replacement > 0) to calibrate
+
+Chris Zhang 9/20/2018
+'''
+
+import pandas as pd
+pd.set_option('display.max_columns', 999)
+pd.set_option('display.width', 200)
+import numpy as np
+from sklearn.neighbors import NearestNeighbors
+
+# a function to prepare data
+def set_data(df):
+    '''
+
+    :param df: fmla_clean_2012.csv
+    :return:
+    '''
+    ## Set index to uniquely identify workers
+    df = df.set_index('empid')
+
+    ## fillna for current leave length
+    df['length'] = df[['LEAVE_CAT', 'length']].groupby('LEAVE_CAT').transform(lambda x: x.fillna(x.mean()))
+
+    ## Consider a program which increases wage replacement
+        # a column to flag 0/1 for any response with increase in leave length
+    df['resp_len'] = np.nan
+        # LEAVE_CAT: employed only
+    df.loc[df['LEAVE_CAT']==3, 'resp_len'] = 0
+        # A55: would take longer if paid?
+    df.loc[(df['resp_len'].isna()) & (df['A55']==2), 'resp_len'] = 0
+    df.loc[(df['resp_len'].isna()) & (df['A55']==1), 'resp_len'] = 1
+        # A23c: unable to afford unpaid leave due to leave taking
+        # A53g: cut leave time short to cover lost wages
+        # A62a: return to work because cannot afford more leaves
+        # B15_1_CAT, B15_2_CAT: can't afford unpaid leave
+    df.loc[(df['resp_len'].isna()) & ((df['A23c']==1) |
+                               (df['A53g']==1) |
+                               (df['A62a']==1) |
+                               (df['B15_1_CAT']==5) |
+                               (df['B15_2_CAT']==5)), 'resp_len'] = 1
+        # A10_1, A10_2: regular/ongoing condition, takers and dual
+        # B11_1, B11_2: regular/ongoing condition, needers and dual
+    df.loc[(df['resp_len'].isna()) & (df['A10_1']==2) | (df['A10_1']==3)
+           | (df['B11_1']==2) | (df['B11_1']==3), 'resp_len'] = 1
+        # Check reasons of no leave among rest: df[df['resp_len'].isna()].B15_1_CAT.value_counts().sort_index()
+        # all reasons unsolved by replacement generosity
+    df.loc[(df['resp_len'].isna()) & (df['B15_1_CAT'].notna()), 'resp_len'] = 0
+    df.loc[(df['resp_len'].isna()) & (df['B15_2_CAT'].notna()), 'resp_len'] = 0
+        # Check LEAVE_CAT of rest: df[df['resp_len'].isna()]['LEAVE_CAT'].value_counts().sort_index()
+        # 267 takers and 3 needers
+        # with no evidence in data of need solvable / unsolvable by $, assume solvable to be conservative
+    df.loc[df['resp_len'].isna(), 'resp_len'] = 1
+    # print(df.resp_len.isna().value_counts())
+
+    # Pool of workers with 'length' not limited by replacement
+    pool = df[(df['resp_len']==0) & (df.length>0)] # pool size = 262 workers
+    # Workers with + response, current length known?
+    # print(df[df['resp_len']==1].length.isna().value_counts()) # 1037 known, 170 missing
+
+    return df, pool
+
+# a function to get weighted mean using v-w columns
+def get_wm_col(df, vws):
+    num = pd.Series(np.zeros(len(df)))
+    denom = pd.Series(np.zeros(len(df)))
+    for v, w in vws:  # vws is list of var-weight tuples [('v0', 'w0'),...]
+        num += df[v] * df[w]
+        denom += df[w]
+    return num / denom
+
+
+# a function to fillna using knn
+def fillna_knn(k, d0, d1, df, ixlabel, cols, v, w, vout):
+    '''
+
+    :param k: k in knn
+    :param d0: df with v known
+    :param d1: df with v missing
+    :param df: master df used to fill in missing values in d0[cols] and d1[cols]
+    :param ixlabel: label of index of d0, d1, and df for consistent merging
+    :param cols: cols used to determine nearest neighbors
+    :param v: label of variable to be filled in d0 and d1
+    :param w: label of weight col in d0
+    :param vout: label of weighted v col in d0 after fillna
+    :return: d0 and d1 appended together, with v filled in
+    '''
+
+    locs0, locs1 = d0[cols], d1[cols]
+
+    # fill in missing values
+    for c in cols:
+        locs0[c] = locs0[c].fillna(df[c].mean())
+        locs1[c] = locs1[c].fillna(df[c].mean())
+        # run kNN
+    nbrs = NearestNeighbors(n_neighbors=k).fit(locs0)
+    distances, indices = nbrs.kneighbors(locs1) # indices=order in locs0, not index of d0
+        # translate indices from knn to index of d0 for merging
+    Nnids = []
+    for row in range(len(locs1)):
+        nnids = []
+        for kk in range(k):
+            i = indices[row][kk]
+            nnids.append(locs0[i:(i + 1)].index[0])  # these are the 2 kNNs (empid) identified
+        Nnids.append(nnids)
+
+        # make a df of nns for empids with missing current length
+    dict_nn = dict(zip(locs1.index, Nnids))
+    dnn = pd.DataFrame.from_dict(dict_nn, orient='index')
+    dnn.index.rename(ixlabel, inplace=True)
+    dnnCols = []
+    for kk in range(k):
+        dnnCols.append('nn%s' % kk)
+    dnn.columns = dnnCols
+
+        # use ixlabel of nns as key to merge with df[[ixlabel, v, w]]
+    d1nn = df.join(dnn, how='right') # wkr dataset with nns, responsive, with length drawn from entire pool
+    for kk in range(k):
+        dfnn = df[[v, w]]
+        dfnn['nn%s' % kk] = df.index
+        dfnn.columns = ['resp%s' % kk, 'w%s' % kk, 'nn%s' % kk]
+        d1nn = pd.merge(d1nn, dfnn, how='left', on='nn%s' % kk)
+
+        # in resulting d1nn, compute weighted length using nns' empid
+    vws = []
+    for kk in range(k):
+        vws += [('resp%s' % kk, 'w%s' % kk)]
+
+    d1nn[vout] = get_wm_col(d1nn, vws)
+    d1nn = d1nn.drop(columns=['nn%s' % kk for kk in range(k)] +
+                                             [x[0] for x in vws] + [x[1] for x in vws])
+                                            # x[0] picks resp<kk>, x[1] picks w<kk>
+
+    # d01 = d0.append(d1nn)
+    return d1nn
+
+def get_resp_length(df, pool, params):
+    # unpack knn parameters
+    k, cols, ixlabel, v, w, vout = params
+
+    # For workers with no response (interior solns), set resp_length = length
+    wkrs_noResp = df[df['resp_len']==0]
+    wkrs_noResp['resp_length'] = wkrs_noResp['length']
+        # up to here, some interior-soln workers did not report length, they are EMPLOYED ONLY, no need
+        # set resp_length = 0
+    wkrs_noResp.loc[wkrs_noResp['LEAVE_CAT']==3, 'resp_length'] = 0
+
+    # For responsive workers with known length, estimate length from pool of workers with greater length
+    resp_wkrs = df[(df['resp_len']==1) & (df['length'].notna())]
+    rwkrs_0nn = [] # list of resp wkrs with no nns, e.g. those with max leave length in entire sample
+    wkrs_rnn_len = pd.DataFrame([])
+    for row in range(len(resp_wkrs)):
+        d1 = resp_wkrs[row:(row+1)] # pick a responsive worker
+        wid = d1.index[0] # empid of responsive worker
+        l = list(d1['length'])[0] # length of this worker's leave taken
+        d0 = pool[pool['length'] > l] # eligible pool of nns are those with greater leave lengths
+        if len(d0) >=k:
+            # use kNN to estimate conditional length
+            d1nn = fillna_knn(k, d0, d1, df, ixlabel, cols, v, w, vout)
+            print('---- d1nn filled in for empid = %s, row %s-th done' % (wid, row))
+            wkrs_rnn_len = wkrs_rnn_len.append(d1nn)
+        else: # if not enough (less than k) leave takers with greater length in poolw
+            rwkrs_0nn.append(wid)
+            print('---->>> empid = %s has large leave length, insufficient eligible neighbors in pool, empid recorded to rwkrs_0nn' % wid)
+
+    # For responsive workers with long length thus 0nn, get response using heuristics
+    wkrs_r0nn_len = df.loc[rwkrs_0nn]
+    wkrs_r0nn_len['resp_length'] = wkrs_r0nn_len['length'] * 1.5 # 1.5x for those w/o nns (long current length)
+
+    # For responsive workers with missing length, draw length from entire pool
+    d0 = pool
+    d1 = df[(df['resp_len']==1) & (df['length'].isna())]
+    wkrs_rnn_noLen = fillna_knn(k, d0, d1, df, ixlabel, cols, v, w, vout)
+
+    # Append 4 resulting dfs:
+    ds = [wkrs_noResp, wkrs_rnn_len, wkrs_r0nn_len, wkrs_rnn_noLen]
+    dfr = pd.DataFrame([])
+    for d in ds:
+        dfr = dfr.append(d)
+
+
+    return dfr
+
+# a function to get parameters
+def get_params():
+    k = 2 # k of kNN
+    cols = ['age',
+            'male',
+            'employed',
+            'wkhours',
+            'noHSdegree', 'BAplus',
+            'empgov_fed', 'empgov_st', 'empgov_loc',
+            'lnfaminc',
+            'black', 'asian', 'hisp', 'other',
+            'ndep_kid', 'ndep_old',
+            'nevermarried', 'partner', 'widowed', 'divorced', 'separated']
+    ixlabel = 'empid'
+    v =  'length'
+    w =  'freq_weight'
+    vout = 'resp_length'
+    params = (k, cols, ixlabel, v, w, vout)
+    return params
+
+# Get response
+def get_response():
+    df = pd.read_csv('./data/fmla_clean_2012.csv')
+    df, pool = set_data(df) # Set data: df, pool
+    params = get_params()
+    dfr = get_resp_length(df, pool, params) # resulting df for all FMLA workers with response length generated
+    dfr.to_csv('./data/fmla_clean_2012_resp_length.csv', index=False)
+    return None
+
+# get_response()
+
+'''
+# some checking
+for d in ds:
+    print(d.resp_length.isna().value_counts())
+
+print('dfr length mean = \n', dfr.length.mean())
+print('dfr resp_length mean = \n', dfr.resp_length.mean())
+'''
+

--- a/cz2_clean_ACS.py
+++ b/cz2_clean_ACS.py
@@ -1,0 +1,247 @@
+
+"""
+This program loads in the raw ACS files, creates the necessary variables
+for the simulation and saves a master dataset to be used in the simulations.
+
+2 March 2018
+hautahi
+
+To do:
+- The biggest missing piece is the imputation of ACS variables using the CPS. These are currently just randomly generated.
+- Check if the ACS variables are the same as those in the C++ code
+
+"""
+
+# -------------------------- #
+# Housekeeping
+# -------------------------- #
+
+import pandas as pd
+pd.set_option('display.max_columns', 999)
+pd.set_option('display.width', 200)
+import numpy as np
+
+# -------------------------- #
+# ACS Household File
+# -------------------------- #
+
+# Load data
+st = 'ma'
+d_hh = pd.read_csv("./data/acs/ss15h%s.csv" % st)
+
+# Create Variables
+d_hh["nochildren"]  = pd.get_dummies(d_hh["FPARC"])[4]
+d_hh['faminc'] = d_hh['FINCP']*d_hh['ADJINC'] / 1042852 # adjust to 2012 dollars to conform with FMLA 2012 data
+d_hh.loc[d_hh['faminc']<=0, 'faminc'] = 0.01 # force non-positive income to be epsilon to get meaningful log-income
+d_hh["lnfaminc"]    = np.log(d_hh["faminc"])
+
+# Number of dependents
+d_hh['ndep_kid'] = d_hh.NOC
+d_hh['ndep_old'] = d_hh.R65
+
+# -------------------------- #
+# ACS Personal File
+# -------------------------- #
+
+# Load data
+d = pd.read_csv("./data/acs/ss15p%s.csv" % st)
+
+# Merge with the household level variables
+d = pd.merge(d,d_hh[['SERIALNO', 'nochildren', 'faminc','lnfaminc','PARTNER', 'ndep_kid', 'ndep_old']],
+                 on='SERIALNO')
+
+# Rename ACS variables to be consistent with FMLA data
+rename_dic = {'AGEP': 'age'}
+d.rename(columns=rename_dic, inplace=True)
+
+# duplicating age column for meshing with CPS estimate output
+d['a_age']=d['age']
+
+# Create new ACS Variables
+d['married'] = pd.get_dummies(d["MAR"])[1]
+d["widowed"]        = pd.get_dummies(d["MAR"])[2]
+d["divorced"]       = pd.get_dummies(d["MAR"])[3]
+d["separated"]      = pd.get_dummies(d["MAR"])[4]
+d["nevermarried"]   = pd.get_dummies(d["MAR"])[5]
+    # use PARTNER in household data to override marital info in personal data
+d['partner'] = 1 - pd.get_dummies(d['PARTNER'])[0] # PARTNER=0: no partner in household
+for m in ['married', 'widowed', 'divorced', 'separated', 'nevermarried']:
+    d.loc[d['partner']==1, m] = 0
+
+d["male"]           = pd.get_dummies(d["SEX"])[1]
+d["female"]         = 1 - d["male"]
+d["agesq"]          = d["age"]**2
+
+# Educational level
+d['ltHS']    = np.where(d['SCHL']<=11,1,0)
+d['someHS']  = np.where((d['SCHL']>=12) & (d['SCHL']<=15),1,0)
+d['HSgrad']  = np.where((d['SCHL']>=16) & (d['SCHL']<=17),1,0)
+d['someCol']  = np.where((d['SCHL']>=18) & (d['SCHL']<=20),1,0)
+d["BA"]      = np.where(d['SCHL']==21,1,0)
+d["GradSch"]  = np.where(d['SCHL']>=22,1,0)
+
+d["noHSdegree"]  = np.where(d['SCHL']<=15,1,0)
+d["BAplus"]  = np.where(d['SCHL']>=21,1,0)
+    # variables for imputing hourly status, using CPS estimates from original model
+d["maplus"]  = np.where(d['SCHL']>=22,1,0)
+d["ba"]      = d['BA']
+
+# race
+
+d['white']= d['RAC1P'].apply(lambda x: int(x==1))
+d['black']= d['RAC1P'].apply(lambda x: int(x==2))
+d['asian']= d['RAC1P'].apply(lambda x: int(x==6))
+d['hisp']= d['HISP'].apply(lambda x: int(x!=1))
+d['other'] = d[['RAC1P', 'hisp']].apply(lambda x: int(x[0]!=1 and x[0]!=2 and x[0]!=6 and x[1]!=1), axis=1)
+
+d['native'] = d['RAC1P'].apply(lambda x: int(x==3 or x==4 or x==5 or x==7))
+
+# Employed
+d['employed'] = np.where((d['ESR']== 1) |
+                         (d['ESR'] == 2) |
+                         (d['ESR'] == 4) |
+                         (d['ESR'] == 5) ,
+                         1, 0)
+d['employed'] = np.where(np.isnan(d['ESR']),np.nan,d['employed'])
+
+# Hours per week, total working weeks
+d['wkhours'] = d['WKHP']
+dict_wks = {
+    1: 51,
+    2: 48.5,
+    3: 43.5,
+    4: 33,
+    5: 20,
+    6: 7
+}
+d['wks'] = d['WKW'].map(dict_wks)
+
+# Total wage past 12m, adjusted to 2012
+d['wage12'] = d['WAGP'] *d['ADJINC'] / 1042852
+
+# Employment at government
+    # missing = age<16, or NILF over 5 years, or never worked
+d['empgov_fed'] = np.where(d['COW']==5, 1, 0)
+d['empgov_fed'] = np.where(np.isnan(d['COW']),np.nan,d['empgov_fed'])
+d['empgov_st'] = np.where(d['COW']==4, 1, 0)
+d['empgov_st'] = np.where(np.isnan(d['COW']),np.nan,d['empgov_st'])
+d['empgov_loc'] = np.where(d['COW']==3, 1, 0)
+d['empgov_loc'] = np.where(np.isnan(d['COW']),np.nan,d['empgov_loc'])
+
+
+# Occupation
+d['occ_1']=0
+d['occ_2']=0
+d['occ_3']=0
+d['occ_4']=0
+d['occ_5']=0
+d['occ_6']=0
+d['occ_7']=0
+d['occ_8']=0
+d['occ_9']=0
+d['occ_10']=0
+d['maj_occ']=0
+d.loc[d['OCCP10']=='N.A.', 'OCCP10'] = np.nan
+d.loc[d['OCCP10'].isnull()==False, 'OCCP10'] = d.loc[d['OCCP10'].isnull()==False, 'OCCP10'].apply(lambda x: int(x))
+d.loc[(d['OCCP10']>=10) & (d['OCCP10']<=950), 'occ_1'] =1
+d.loc[(d['OCCP10']>=1000) & (d['OCCP10']<=3540), 'occ_2'] =1
+d.loc[(d['OCCP10']>=3600) & (d['OCCP10']<=4650), 'occ_3'] =1
+d.loc[(d['OCCP10']>=4700) & (d['OCCP10']<=4965), 'occ_4'] =1
+d.loc[(d['OCCP10']>=5000) & (d['OCCP10']<=5940), 'occ_5'] =1
+d.loc[(d['OCCP10']>=6000) & (d['OCCP10']<=6130), 'occ_6'] =1
+d.loc[(d['OCCP10']>=6200) & (d['OCCP10']<=6940), 'occ_7'] =1
+d.loc[(d['OCCP10']>=7000) & (d['OCCP10']<=7630), 'occ_8'] =1
+d.loc[(d['OCCP10']>=7700) & (d['OCCP10']<=8965), 'occ_9'] =1
+d.loc[(d['OCCP10']>=9000) & (d['OCCP10']<=9750), 'occ_10'] =1
+
+# Industry
+d['ind_1']=0
+d['ind_2']=0
+d['ind_3']=0
+d['ind_4']=0
+d['ind_5']=0
+d['ind_6']=0
+d['ind_7']=0
+d['ind_8']=0
+d['ind_9']=0
+d['ind_10']=0
+d['ind_11']=0
+d['ind_12']=0
+d['ind_13']=0
+d.loc[(d['INDP']>=170) & (d['INDP']<=290), 'ind_1'] =1
+d.loc[(d['INDP']>=370) & (d['INDP']<=490), 'ind_2'] =1
+d.loc[(d['INDP']==770), 'ind_3'] =1
+d.loc[(d['INDP']>=1070) & (d['INDP']<=3990), 'ind_4'] =1
+d.loc[(d['INDP']>=4070) & (d['INDP']<=5790), 'ind_5'] =1
+d.loc[((d['INDP']>=6070) & (d['INDP']<=6390))|((d['INDP']>=570) & (d['INDP']<=690)), 'ind_6'] =1
+d.loc[(d['INDP']>=6470) & (d['INDP']<=6780), 'ind_7'] =1
+d.loc[(d['INDP']>=6870) & (d['INDP']<=7190), 'ind_8'] =1
+d.loc[(d['INDP']>=7270) & (d['INDP']<=7790), 'ind_9'] =1
+d.loc[(d['INDP']>=7860) & (d['INDP']<=8470), 'ind_10'] =1
+d.loc[(d['INDP']>=8560) & (d['INDP']<=8690), 'ind_11'] =1
+d.loc[(d['INDP']>=8770) & (d['INDP']<=9290), 'ind_12'] =1
+d.loc[(d['INDP']>=9370) & (d['INDP']<=9590), 'ind_13'] =1
+
+# -------------------------- #
+# Remove ineligible workers
+# -------------------------- #
+
+# Restrict dataset to civilian employed workers (check this)
+    # d = d[(d['ESR'] == 1) | (d['ESR'] == 2)]
+
+#  Restrict dataset to those that are not self-employed
+    # d = d[(d['COW'] != 6) & (d['COW'] != 7)]
+
+# -------------------------- #
+# CPS Imputation
+# -------------------------- #
+
+"""
+Not all the required behavioral independent variables are available
+within the ACS. These therefore need to be imputed CPS
+
+d["weeks_worked"] = 
+d["weekly_earnings"] = 
+"""
+
+# These are just placeholders for now
+# d["coveligd"] = np.nan
+# d['union'] = np.nan
+
+# adding in the prhourly worker imputation
+# Double checked C++ code, and confirmed this is how they did hourly worker imputation.
+hr_est=pd.read_csv('estimates/CPS_paid_hrly.csv').set_index('var').to_dict()['est']
+d['prhourly']=0
+for dem in hr_est.keys():
+    if dem!='Intercept':
+        d['prhourly']+=d[dem].fillna(0)*hr_est[dem]
+d['prhourly']+=hr_est['Intercept']
+d['prhourly']=np.exp(d['prhourly'])/(1+np.exp(d['prhourly']))
+d['rand']=pd.Series(np.random.rand(d.shape[0]), index=d.index)
+d['hourly']= np.where(d['prhourly']>d['rand'],1,0)
+d=d.drop('rand', axis=1)
+
+# -------------------------- #
+# Save the resulting dataset
+# -------------------------- #
+cols = ['SERIALNO', 'PWGTP', 'ST',
+'hourly',
+'employed', 'empgov_fed','empgov_st','empgov_loc',
+'wkhours', 'wks', 'wage12',
+'age', 'agesq',
+'male',
+'nochildren', 'ndep_kid', 'ndep_old',
+'ltHS', 'someHS', 'HSgrad', 'someCol', 'BA', 'GradSch', 'noHSdegree', 'BAplus' ,
+'faminc', 'lnfaminc',
+'married', 'partner', 'separated', 'divorced', 'widowed', 'nevermarried',
+'native', 'asian', 'black', 'white', 'other', 'hisp',
+'ESR', 'COW' # original ACS vars for restricting samples later
+        ]
+d_reduced = d[cols]
+d_reduced.to_csv("./data/acs/ACS_cleaned_forsimulation_%s.csv" % st, index=False, header=True)
+
+    # a wage only file for testing ABF
+# d2 = d_reduced[['wage12','PWGTP']]
+# d2.to_csv("./data/acs/ACS_cleaned_forsimulation_%s_wage.csv" % st, index=False, header=True)
+
+

--- a/cz3_simulation_engine.py
+++ b/cz3_simulation_engine.py
@@ -1,0 +1,91 @@
+'''
+Simulate leave taking behavior of ACS sample, using FMLA data
+
+to do:
+1. Need to think more about imputation to fill in missing values before kNN
+2. Need to impute coveligd, more from ACM model
+3. Need to compute counterfactual 'length' of leave for FMLA samples under new program
+
+Chris Zhang 9/13/2018
+'''
+
+import pandas as pd
+pd.set_option('display.max_columns', 999)
+pd.set_option('display.width', 200)
+import numpy as np
+from sklearn.neighbors import NearestNeighbors
+import random
+from cz3a_simulate_knn import simulate_knn
+
+# Algorithm parameter
+k = 2
+
+# State
+st = 'ma'
+
+# Data
+fmla = pd.read_csv('./data/fmla_clean_2012_resp_length.csv')
+acs = pd.read_csv('./data/acs/ACS_cleaned_forsimulation_%s.csv' % st)
+
+# kNN
+k = 2
+Xs = ['age',
+            'male',
+            'employed',
+            'wkhours',
+            'noHSdegree', 'BAplus',
+            'empgov_fed', 'empgov_st', 'empgov_loc',
+            'lnfaminc',
+            'black', 'asian', 'hisp', 'other',
+            'ndep_kid', 'ndep_old',
+            'nevermarried', 'partner','widowed', 'divorced', 'separated']
+
+acs['resp_length_full'] = simulate_knn(k, fmla, acs, Xs, 'resp_length')
+
+# Compute total program cost
+    # replacement rate
+rr = 0.25
+    # restrict to relevant persons in ACS
+acs = acs[(acs.age>=18)]
+acs = acs.drop(index=acs[acs.ESR==4].index) # armed forces at work
+acs = acs.drop(index=acs[acs.ESR==5].index) # armed forces with job but not at work
+acs = acs.drop(index=acs[acs.ESR==6].index) # NILF
+acs = acs.drop(index=acs[acs.COW==6].index) # self-employed, not incorporated
+acs = acs.drop(index=acs[acs.COW==7].index) # self-employed, incoporated
+acs = acs.drop(index=acs[acs.COW==8].index) # working without pay in family biz
+acs = acs.drop(index=acs[acs.COW==9].index) # unemployed for 5+ years, or never worked
+
+    # FMLA eligibility
+acs['coveligd'] = 0
+        # set as 1 for all gov workers
+acs.loc[acs['empgov_fed']==1, 'coveligd'] = 1
+acs.loc[acs['empgov_st']==1, 'coveligd'] = 1
+acs.loc[acs['empgov_loc']==1, 'coveligd'] = 1
+        # set as 1 for all workers with annual hours >= 1250
+acs['yrhours'] = acs['wkhours'] * acs['wks']
+acs.loc[acs['yrhours']>=1250, 'coveligd'] = 1
+del acs['yrhours']
+        # check wm-eligibility against FMLA
+coveligd_wm_acs = sum(acs['coveligd']*acs['PWGTP']) / sum(acs['PWGTP'])
+coveligd_wm_fmla = (fmla['coveligd']*fmla['freq_weight']).sum() / fmla[fmla.coveligd.isna()==False]['freq_weight'].sum()
+x = coveligd_wm_acs/coveligd_wm_fmla
+print('Estimated mean eligibility in ACS = %s times of mean eligibility in FMLA data' % round(x, 3))
+
+    # daily wage
+acs['wage1d'] = acs['wage12'] / acs['wks'] / 5
+acs.loc[acs['wage12']==0, 'wage1d'] = 0 # hopefully this solves all missing wage1d cases
+
+    # total program cost
+acs['cost_rep'] = acs['resp_length_full'] * acs['wage1d'] * acs['PWGTP'] * acs['coveligd'] * rr
+TC = round(sum(acs['cost_rep'])/10**9, 3)
+print('Method = kNN(k=%s), State = %s, Replacement rate = %s, Total Program Cost = $%s billion' % (k, st, rr, TC))
+
+
+'''
+vs = ['cost_rep','length','wage1d','PWGTP','coveligd']
+vs = ['wage12', 'wks']
+for v in vs:
+    print(acs[v].isna().value_counts())
+
+'''
+

--- a/cz3a_simulate_knn.py
+++ b/cz3a_simulate_knn.py
@@ -1,0 +1,53 @@
+'''
+simulator - knn
+
+Chris Zhang 9/24/2018
+'''
+
+import pandas as pd
+pd.set_option('display.max_columns', 999)
+pd.set_option('display.width', 200)
+import numpy as np
+from sklearn.neighbors import NearestNeighbors
+import random
+from cz1a_get_response import get_params, get_wm_col
+
+def simulate_knn(k, fmla, acs, Xs, var):
+    '''
+
+    :param k: k in knn
+    :param fmla: fmla df, with response var column
+    :param acs: acs df
+    :param Xs: cols used for knn
+    :param var: var of interest to be sourced from fmla
+    :return: response var column for all acs ppl
+    '''
+    locs_fmla, locs_acs = fmla[Xs], acs[Xs] # locations of FMLA and ACS rows in space defined by knn_cols
+        # impute missing values
+    locs_fmla = locs_fmla.fillna(locs_fmla.mean())
+    locs_acs = locs_acs.fillna(locs_acs.mean())
+        # run kNN
+    nbrs = NearestNeighbors(n_neighbors=k).fit(locs_fmla)
+    distances, indices = nbrs.kneighbors(locs_acs)
+    ns_nn = [len(pd.DataFrame(indices)[x].value_counts()) for x in range(k)]
+    print('Number of FMLA workers found as 1st,..., %s-th, nearest neighbors = %s' % (k, ns_nn))
+        # use kNN indices to merge with FMLA data
+    for kk in range(k):
+        acs['idx_nn%s' % kk] = pd.DataFrame(indices)[kk]
+        fmla['idx_nn%s' % kk] = fmla.index # equivalent cols for merging
+    for kk in range(k):
+        acs = pd.merge(acs, fmla[['idx_nn%s' % kk, 'freq_weight', var]], how='left', on='idx_nn%s' % kk)
+        acs.rename(columns={'freq_weight': 'w%s' % kk, var: '%s%s' % (var, kk)}, inplace=True)
+        acs['%s%s' % (var, kk)] = acs['%s%s' % (var, kk)].fillna(0)
+        # compute outvars to be simulated
+    vws = []
+    for kk in range(k):
+        vws += [('%s%s' % (var, kk), 'w%s' % kk)]
+
+        # Fully responsive length - if program is generous enough so that needers will have interior solutions
+    var_for_acs = get_wm_col(acs, vws)
+
+        # clean up resulting df
+    acs = acs.drop(columns=['idx_nn%s' % kk for kk in range(k)] + [vw[0] for vw in vws] + [vw[1] for vw in vws])
+
+    return var_for_acs


### PR DESCRIPTION
cz1_clean_FMLA.py: fixed issues with defining new indicators, included government worker vars
cz1a_get_response.py: exploit bounding / not by financial concerns in leave taking behavior, and simulate counterfactual leave lengths under a more generous program, output a FMLA CSV with a new column 'resp_length' = (weakly) longer counterfactual leave length
cz2_clean_ACS.py: fixed issues with defining new indicators, included government worker vars
cz3_simulation_engine.py: main simulation engine, computing total program cost, need to calibrate parameter that represents the effect of replacement rate on leave length
cz3a_simulate_knn.py: a function of knn simulation